### PR TITLE
Fix timestamp generation for opentsdb datapoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 ### Changed
  - PNDA-2700: Update spark streaming example to work on redhat.
 
+### Fixed
+ - PNDA-3051: Fix timestamp generation for opentsdb datapoints
+
 ### Added
 - PNDA-2726: Added example spark-batch and spark-streaming jobs in python
 

--- a/kafka-spark-opentsdb/build.sbt
+++ b/kafka-spark-opentsdb/build.sbt
@@ -1,6 +1,6 @@
 name := "PNDA KSO sample app"
 
-version := "1.0.0"
+version := "1.0.2"
 
 scalaVersion := "2.10.5"
 

--- a/kafka-spark-opentsdb/src/main/scala/com/cisco/pnda/OpenTSDBOutput.scala
+++ b/kafka-spark-opentsdb/src/main/scala/com/cisco/pnda/OpenTSDBOutput.scala
@@ -24,7 +24,7 @@ express or implied.
 
 package com.cisco.pnda;
 
-import java.sql.Timestamp
+import org.joda.time.DateTime
 import scala.util.control.NonFatal
 import org.apache.log4j.Logger
 import org.apache.spark.streaming.dstream.DStream
@@ -52,8 +52,7 @@ class OpenTSDBOutput extends Serializable {
           val collectd_type = compact(render((json \\ "collectd_type"))).replace("\"", "")
           var metric:String = "kso.collectd"
           metric = metric.concat("." + collectd_type)
-          val timestamp = Timestamp.valueOf(timestampStr.replace("T"," ").replace("Z","")).getTime
-
+          val timestamp = new DateTime(timestampStr).getMillis
           val body = f"""{
                     |        "metric": "$metric",
                     |        "value": "$value",


### PR DESCRIPTION
Previously this would go wrong when run on non-utc zoned instances.

PNDA-3051