### PR TITLE
align kafka-python version to 1.3.5 with the one in mirror

### DIFF
--- a/kafka-spark-opentsdb/data-source/requirements.txt
+++ b/kafka-spark-opentsdb/data-source/requirements.txt
@@ -1,3 +1,3 @@
 avro==1.8.1
-kafka-python==1.3.1
+kafka-python==1.3.5
 six==1.10.0


### PR DESCRIPTION
PNDA-4196