### PR TITLE
Update kafka-python package version to 1.3.5

### DIFF
--- a/spark-streaming/data-source/src/main/resources/requirements.txt
+++ b/spark-streaming/data-source/src/main/resources/requirements.txt
@@ -1,2 +1,2 @@
 avro==1.8.1
-kafka-python==0.9.5
+kafka-python==1.3.5


### PR DESCRIPTION
**Analysis:**
Kafka-python package need to be updated to 1.3.5 to produce the data.

**Changed:**
Updated the kafka-python package version in requirement.txt and modified the script with new APIs.

**Test Details:**
AWS-RHEL-PICO-HDP
AWS-RHEL-STD-HDP